### PR TITLE
Change load order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,10 @@ compile:
 	./rebar3 compile
 
 priv/$(nif_lib): src/lib.rs
+ifneq ($(ECRECOVER_DISABLE_NIF_BUILD), true)
 	cargo build --release
 	cp target/release/$(nif_lib_src) $@
+endif
 
 clean:
 	rm -f priv/$(nif_lib) target/release/$(nif_lib_src)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,29 @@
 # ecrecover
 FFI (NIF) export of Ethereum's ecrecover for use from Erlang.
 
-### prerequisite:
-- a checked out copy of my fork of parity-ethereum (https://github.com/johnsnewby/parity-ethereum) checked out into this directory this is (i.e. it will be referenced as `./parity-ethereum`)
+### Prerequisites
+The NIF is written in Rust, therefore the following additional build
+dependencies are needed:
 
-### to compile:
-`cargo build`
+- Rust
+- Cargo
+- Cmake
+
+### Build
+Execute:
+```
+make
+```
+
+To disable the local build of the NIF library, e.g. to use a prebuilt binary,
+use the following command:
+```
+ECRECOVER_DISABLE_NIF_BUILD=true make
+```
 
 ## Erlang integration
 
-The shared library uses NIF. Use the erlang file `src/ecrecover.erl` to use this:
+The shared library uses NIF. Use the Erlang file `src/ecrecover.erl` to use this:
 
 ```
 c("src/ecrecover").

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,20 @@
+let
+  stable = import (fetchTarball { # 19.09
+    url = https://github.com/NixOS/nixpkgs-channels/archive/a22b0189002.tar.gz;
+    sha256 = "0rgd0cbxg9mrzb830hgjlvy134ivpfcnkyhbnlvvn8vl4y20zqmz";
+  }) {};
+in {
+  aeternityEnv = stable.stdenv.mkDerivation {
+    name = "ecrecover";
+    buildInputs = [
+      ## base
+      stable.stdenv
+      ## erlang
+      stable.erlangR21 # OTP 21.3.5.2
+      ## rust, required for building the NIF
+      stable.rustc
+      stable.cargo
+      stable.cmake
+    ];
+  };
+}


### PR DESCRIPTION
By preferring the local NIF build one can actually build and run on a platform which doesn't have prebuilt binaries.