### PR TITLE
Fix returning value in NIF to avoid crashing VM; add FreeBSD support

### DIFF
--- a/c_src/ecrecover.c
+++ b/c_src/ecrecover.c
@@ -3,6 +3,7 @@
 
 #include "erl_nif.h"
 #include "secp256k1_recovery.h"
+#include <string.h>
 
 
 static secp256k1_context *ctx = NULL;
@@ -12,9 +13,68 @@ static ERL_NIF_TERM error_result(ErlNifEnv* env, char* error_msg)
     return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_string(env, error_msg, ERL_NIF_LATIN1));
 }
 
+static ERL_NIF_TERM ok3_result(ErlNifEnv* env, ERL_NIF_TERM *r1, ERL_NIF_TERM *r2)
+{
+    return enif_make_tuple3(env, enif_make_atom(env, "ok"), *r1, *r2);
+}
+
 static ERL_NIF_TERM ok_result(ErlNifEnv* env, ERL_NIF_TERM *r)
 {
     return enif_make_tuple2(env, enif_make_atom(env, "ok"), *r);
+}
+
+static ERL_NIF_TERM
+sign(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+  ErlNifBinary messagedigest, privkey, nonce;
+
+  if (!enif_inspect_binary(env, argv[0], &messagedigest)) {
+    return enif_make_badarg(env);
+  }
+
+  if (!enif_inspect_binary(env, argv[1], &privkey)) {
+    return enif_make_badarg(env);
+  }
+
+  if (!enif_inspect_binary(env, argv[2], &nonce)) {
+    return enif_make_badarg(env);
+  }
+
+  secp256k1_ecdsa_recoverable_signature *signature;
+  int recoveryid;
+
+  signature = malloc(sizeof(secp256k1_ecdsa_recoverable_signature));
+  memset(signature, 0, sizeof(secp256k1_ecdsa_recoverable_signature));
+  if(!signature) {
+    return error_result(env, "malloc_error");
+  }
+
+  ERL_NIF_TERM to_ret;
+  unsigned char* out = enif_make_new_binary(env, 64, &to_ret);
+
+  int result = secp256k1_ecdsa_sign_recoverable(
+      ctx,
+      signature,
+      messagedigest.data,
+      privkey.data,
+      NULL,
+      nonce.data);
+  if (!result) {
+    free(signature);
+    //should out be freed here??
+    return error_result(env, "sign_error");
+  }
+  secp256k1_ecdsa_recoverable_signature_serialize_compact(
+      ctx,
+      out,
+      &recoveryid,
+      signature);
+
+  free(signature);
+
+  ERL_NIF_TERM v = enif_make_uint(env, recoveryid && 0xff);
+
+  return ok3_result(env, &to_ret, &v);
 }
 
 static ERL_NIF_TERM
@@ -95,7 +155,8 @@ unload(ErlNifEnv* env, void* priv)
 
 static ErlNifFunc nif_funcs[] =
   {
-   {"recover", 3, recover}
+   {"recover", 3, recover},
+   {"sign", 3, sign}
   };
 
 ERL_NIF_INIT(ecrecover, nif_funcs, &load, NULL, NULL, &unload);

--- a/c_src/ecrecover.c
+++ b/c_src/ecrecover.c
@@ -42,8 +42,8 @@ recover(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 		return error_result(env, "Recovery id invalid not integer 0-3");
 	}
 
-    if (recid < 0 || recid > 3) {
-		error_result(env, "Recovery id invalid 0-3");
+	if (recid < 0 || recid > 3) {
+		return error_result(env, "Recovery id invalid 0-3");
 	}
 
     result = secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &signature, csignature.data, recid);

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps,
-  [{sha3, {git, "https://github.com/aeternity/erlang-sha3", {ref, "b5f27a2"}}}]}.
+  [ ]}.
 
 {pre_hooks, [ {compile, "./secp256k1.sh"} ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -17,6 +17,10 @@
             , {"darwin", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -finline-functions -Wall"}
             , {"darwin", "LDFLAGS", "$LDFLAGS c_src/secp256k1/.libs/libsecp256k1.a"}
 
+            , {"freebsd", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -I c_src/secp256k1/include"}
+            , {"freebsd", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -finline-functions -Wall"}
+            , {"freebsd", "LDFLAGS", "$LDFLAGS c_src/secp256k1/.libs/libsecp256k1.a"}
+
             , {"linux", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -I c_src/secp256k1/include"}
             , {"linux", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -finline-functions -Wall"}
             , {"linux", "LDFLAGS", "$LDFLAGS c_src/secp256k1/.libs/libsecp256k1.a"}

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,12 +1,1 @@
-{"1.2.0",
-[{<<"hex2bin">>,{pkg,<<"hex2bin">>,<<"1.0.0">>},1},
- {<<"sha3">>,
-  {git,"https://github.com/aeternity/erlang-sha3",
-       {ref,"b5f27a29ba1179e5907c50d7ec7aa79b2857e981"}},
-  0}]}.
-[
-{pkg_hash,[
- {<<"hex2bin">>, <<"AAC26EAB998AE80EACEE1C7607C629AB503EBF77A62B9242BAE2B94D47DCB71E">>}]},
-{pkg_hash_ext,[
- {<<"hex2bin">>, <<"E7012D1D9AADD26E680F0983D26FB8923707F05FAC9688F19F530FA3795E716F">>}]}
-].
+[].

--- a/src/ecrecover.app.src
+++ b/src/ecrecover.app.src
@@ -4,8 +4,7 @@
   {registered, []},
   {applications,
    [kernel,
-    stdlib,
-    sha3
+    stdlib
    ]},
   {env,[]},
   {modules, []},

--- a/src/ecrecover.erl
+++ b/src/ecrecover.erl
@@ -1,7 +1,7 @@
 -module(ecrecover).
 
 %% API
--export([recover/2, recover/3]).
+-export([recover/2, recover/3, sign/3]).
 
 %% NIF
 -export([load/0]).
@@ -36,8 +36,12 @@ recover(Hash, <<V, Sig:64/binary>>) when V == 27; V == 28 ->
 recover(_Hash, _VSig) ->
     <<0:256>>.
 
--spec recover(<<_:(32*8)>>, <<_:(64*8)>>, integer()) -> <<_:(32*8)>>.
+-spec recover(<<_:(32*8)>>, <<_:(64*8)>>, integer()) -> {ok,<<_:(65*8)>>}.
 recover(_Hash, _Sig, _RecId) ->
+    not_loaded(?LINE).
+
+-spec sign(<<_:256>>, <<_:256>>, <<_:256>>) -> {ok,<<_:272>>,integer()}.
+sign(_Hash, _Priv, _Nonce) ->
     not_loaded(?LINE).
 
 %%=============================================================================


### PR DESCRIPTION
I use recover/3 in my code to get public key (without recover/2 wrapper) and noticed that illegal value in RecId crashes my VM.
Here is a fix.
Also I added freebsd support in rebar.conf. It works